### PR TITLE
Fmh fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ grep "^D\-" ${RESULTS_PATH}/generate-${GEN_SUBSET}.txt | \
   > ${RESULTS_PATH}/generate-${GEN_SUBSET}.unit
 
 grep "^T\-" ${RESULTS_PATH}/generate-${GEN_SUBSET}.txt  | \
-  sed 's/^T-//ig' | sort -nk1 | cut -f2 
+  sed 's/^T-//ig' | sort -nk1 | cut -f2 \
   > ${RESULTS_PATH}/ref-${GEN_SUBSET}.unit
 ```
  * Set `--dur-prediction` for generating audio for S2UT _reduced_ models.

--- a/README.md
+++ b/README.md
@@ -183,8 +183,8 @@ fairseq-train $DATA_ROOT \
   --lr 0.0005 --lr-scheduler inverse_sqrt --warmup-init-lr 1e-7 --warmup-updates 10000 \
   --optimizer adam --adam-betas "(0.9,0.98)" --clip-norm 10.0 \
   --max-update 400000 --max-tokens 20000 --max-target-positions 3000 --update-freq 4 \
-  --seed 1 --fp16 --num-workers 8
-   --user-dir research/  --attn-type espnet --pos-enc-type rel_pos 
+  --seed 1 --fp16 --num-workers 8 \
+  --user-dir research/  --attn-type espnet --pos-enc-type rel_pos 
 ```
 * Adjust `--update-freq` accordingly for different #GPUs. In the above we set `--update-freq 4` to simulate training with 4 GPUs.
 
@@ -193,8 +193,8 @@ fairseq-train $DATA_ROOT \
 1. Follow the same inference process as in fairseq-S2T to generate unit sequences (${RESULTS_PATH}/generate-${GEN_SUBSET}.txt).
 ```
 fairseq-generate $DATA_ROOT \
---gen-subset test --task speech_to_speech_fasttranslate  --path ${MODEL_DIR}
- --target-is-code --target-code-size 100 --vocoder code_hifigan   --results-path ${OUTPUT_DIR}
+ --gen-subset test --task speech_to_speech_fasttranslate  --path ${MODEL_DIR} \
+ --target-is-code --target-code-size 1000 --vocoder code_hifigan   --results-path ${OUTPUT_DIR} \
  --iter-decode-max-iter $N  --iter-decode-eos-penalty 0 --beam 1   --iter-decode-with-beam 15 
 ```
 
@@ -205,8 +205,8 @@ grep "^D\-" ${RESULTS_PATH}/generate-${GEN_SUBSET}.txt | \
   > ${RESULTS_PATH}/generate-${GEN_SUBSET}.unit
 
 grep "^T\-" ${RESULTS_PATH}/generate-${GEN_SUBSET}.txt  | \
-sed 's/^T-//ig' | sort -nk1 | cut -f2 
- > ${RESULTS_PATH}/ref-${GEN_SUBSET}.unit
+  sed 's/^T-//ig' | sort -nk1 | cut -f2 
+  > ${RESULTS_PATH}/ref-${GEN_SUBSET}.unit
 ```
  * Set `--dur-prediction` for generating audio for S2UT _reduced_ models.
  

--- a/research/TranSpeech/iterative_refinement_generator.py
+++ b/research/TranSpeech/iterative_refinement_generator.py
@@ -158,7 +158,7 @@ class IterativeRefinementGenerator(object):
 
             bsz = bsz * self.beam_size
 
-        sent_idxs = torch.arange(bsz)
+        sent_idxs = torch.arange(bsz).to(device="cuda")
         prev_output_tokens = prev_decoder_out.output_tokens.clone()
 
         if self.retain_history:
@@ -304,7 +304,7 @@ class IterativeRefinementGenerator(object):
                 finalized[
                     np.argmax(
                         [
-                            finalized[self.beam_size * i + j][0]["score"]
+                            finalized[self.beam_size * i + j][0]["score"].cpu()
                             for j in range(self.beam_size)
                         ]
                     )


### PR DESCRIPTION
> 关于**README.md**中的修改

由于**Training S2UT model**中使用的**target-code-size**为**1000**，在使用训练后的模型进行**Inference with NAR S2UT model**时，会有如下报错。
```shell
Traceback (most recent call last):
  File "/root/autodl-tmp/fangminghui/miniconda3/envs/transpeech/bin/fairseq-generate", line 33, in <module>
    sys.exit(load_entry_point('fairseq', 'console_scripts', 'fairseq-generate')())
  File "/root/autodl-tmp/fangminghui/project/transpeech/fairseq_cli/generate.py", line 446, in cli_main
    main(args)
  File "/root/autodl-tmp/fangminghui/project/transpeech/fairseq_cli/generate.py", line 48, in main
    return _main(cfg, h)
  File "/root/autodl-tmp/fangminghui/project/transpeech/fairseq_cli/generate.py", line 96, in _main
    models, saved_cfg = checkpoint_utils.load_model_ensemble(
  File "/root/autodl-tmp/fangminghui/project/transpeech/fairseq/checkpoint_utils.py", line 364, in load_model_ensemble
    ensemble, args, _task = load_model_ensemble_and_task(
  File "/root/autodl-tmp/fangminghui/project/transpeech/fairseq/checkpoint_utils.py", line 479, in load_model_ensemble_and_task
    model.load_state_dict(
  File "/root/autodl-tmp/fangminghui/project/transpeech/fairseq/models/fairseq_model.py", line 128, in load_state_dict
    return super().load_state_dict(new_state_dict, strict)
  File "/root/autodl-tmp/fangminghui/miniconda3/envs/transpeech/lib/python3.8/site-packages/torch/nn/modules/module.py", line 1667, in load_state_dict
    raise RuntimeError('Error(s) in loading state_dict for {}:\n\t{}'.format(
RuntimeError: Error(s) in loading state_dict for NARS2UTConformerModel:
	size mismatch for decoder.embed_tokens.weight: copying a param with shape torch.Size([1004, 512]) from checkpoint, the shape in current model is torch.Size([104, 512]).
	size mismatch for decoder.output_projection.weight: copying a param with shape torch.Size([1004, 512]) from checkpoint, the shape in current model is torch.Size([104, 512]).
```
所以我将**Inference with NAR S2UT model**的**target-code-size**更改为**1000**。

> 关于**research/TranSpeech/iterative_refinement_generator.py**的修改

运行**Inference with NAR S2UT model**时有如下报错。
```shell
Traceback (most recent call last):                                                                                                                                                         
  File "/root/autodl-tmp/fangminghui/miniconda3/envs/transpeech/bin/fairseq-generate", line 33, in <module>
    sys.exit(load_entry_point('fairseq', 'console_scripts', 'fairseq-generate')())
  File "/root/autodl-tmp/fangminghui/project/transpeech/fairseq_cli/generate.py", line 446, in cli_main
    main(args)
  File "/root/autodl-tmp/fangminghui/project/transpeech/fairseq_cli/generate.py", line 48, in main
    return _main(cfg, h)
  File "/root/autodl-tmp/fangminghui/project/transpeech/fairseq_cli/generate.py", line 201, in _main
    hypos = task.inference_step(
  File "/root/autodl-tmp/fangminghui/project/transpeech/fairseq/tasks/speech_to_speech.py", line 591, in inference_step
    return super().inference_step(
  File "/root/autodl-tmp/fangminghui/project/transpeech/fairseq/tasks/fairseq_task.py", line 537, in inference_step
    return generator.generate(
  File "/root/autodl-tmp/fangminghui/miniconda3/envs/transpeech/lib/python3.8/site-packages/torch/autograd/grad_mode.py", line 27, in decorate_context
    return func(*args, **kwargs)
  File "/root/autodl-tmp/fangminghui/project/transpeech/research/TranSpeech/iterative_refinement_generator.py", line 243, in generate
    finalized_idxs = sent_idxs[terminated]
RuntimeError: indices should be either on cpu or on the same device as the indexed tensor (cpu)
```
所以我将**sent_idxs**移动到**GPU**上。

另一个报错如下。
```shell
Traceback (most recent call last):                                                                                                                                                         
  File "/root/autodl-tmp/fangminghui/miniconda3/envs/transpeech/bin/fairseq-generate", line 33, in <module>
    sys.exit(load_entry_point('fairseq', 'console_scripts', 'fairseq-generate')())
  File "/root/autodl-tmp/fangminghui/project/transpeech/fairseq_cli/generate.py", line 446, in cli_main
    main(args)
  File "/root/autodl-tmp/fangminghui/project/transpeech/fairseq_cli/generate.py", line 48, in main
    return _main(cfg, h)
  File "/root/autodl-tmp/fangminghui/project/transpeech/fairseq_cli/generate.py", line 201, in _main
    hypos = task.inference_step(
  File "/root/autodl-tmp/fangminghui/project/transpeech/fairseq/tasks/speech_to_speech.py", line 591, in inference_step
    return super().inference_step(
  File "/root/autodl-tmp/fangminghui/project/transpeech/fairseq/tasks/fairseq_task.py", line 537, in inference_step
    return generator.generate(
  File "/root/autodl-tmp/fangminghui/miniconda3/envs/transpeech/lib/python3.8/site-packages/torch/autograd/grad_mode.py", line 27, in decorate_context
    return func(*args, **kwargs)
  File "/root/autodl-tmp/fangminghui/project/transpeech/research/TranSpeech/iterative_refinement_generator.py", line 303, in generate
    finalized = [
  File "/root/autodl-tmp/fangminghui/project/transpeech/research/TranSpeech/iterative_refinement_generator.py", line 305, in <listcomp>
    np.argmax(
  File "<__array_function__ internals>", line 180, in argmax
  File "/root/autodl-tmp/fangminghui/miniconda3/envs/transpeech/lib/python3.8/site-packages/numpy/core/fromnumeric.py", line 1216, in argmax
    return _wrapfunc(a, 'argmax', axis=axis, out=out, **kwds)
  File "/root/autodl-tmp/fangminghui/miniconda3/envs/transpeech/lib/python3.8/site-packages/numpy/core/fromnumeric.py", line 54, in _wrapfunc
    return _wrapit(obj, method, *args, **kwds)
  File "/root/autodl-tmp/fangminghui/miniconda3/envs/transpeech/lib/python3.8/site-packages/numpy/core/fromnumeric.py", line 43, in _wrapit
    result = getattr(asarray(obj), method)(*args, **kwds)
  File "/root/autodl-tmp/fangminghui/miniconda3/envs/transpeech/lib/python3.8/site-packages/torch/_tensor.py", line 955, in __array__
    return self.numpy()
TypeError: can't convert cuda:0 device type tensor to numpy. Use Tensor.cpu() to copy the tensor to host memory first.
```
所以我将**finalized**移动到**CPU**上。

经过以上修改，**Inference with NAR S2UT model**可以正常跑起来。